### PR TITLE
Fixes issue #1: highest rank threshold message and updating error

### DIFF
--- a/src/invitesCalc.js
+++ b/src/invitesCalc.js
@@ -6,22 +6,16 @@ import updateme from './commands/updateme.js';
 const invitesCalc = (bot, msg, cmd) => {
   const richEmbed = new Discord.RichEmbed();
   let user = msg.author.id;
-  let numberUses;
-  let max = 0;
+  let numberUses = 0;
   let invites = msg.guild.fetchInvites()
     .then(result => {
       let inviteArr = result.array();
       for (let i = 0; i < inviteArr.length; i++) {
         let invite = inviteArr[i];
         if (invite.inviter.id === user) {
-          numberUses = invite.uses;
-
-          if (numberUses > max) {
-            max = numberUses;
-          }
+          numberUses += invite.uses;
         }
       }
-      numberUses = max;
 
       let roleNames = Object.keys(customRoles);
       let roleNums = Object.values(customRoles);
@@ -38,13 +32,14 @@ const invitesCalc = (bot, msg, cmd) => {
         msg.channel.send({
           embed: richEmbed
                   .setColor('#ffffff')
-                  .setDescription(`You are the highest role of ${msg.member.highestRole} with ${numberUses} invites.`)
+                  .setDescription(`You are the highest role of **${roleNames[5]}** with ${numberUses} invites.`)
         })
-        return; // no calculation needed
+        updateme(msg, numberUses, numberLeft, nextRole);
+        return; // no further calculation needed
       }
       let numberLeft = roleNumber - numberUses;
       let hasInviteLink = true;
-      if (isNaN(numberLeft)) hasInviteLink = false;
+      if (isNaN(numberLeft) && numberUses === 0) hasInviteLink = false;
 
       if (hasInviteLink) {
         invitesCmd(msg, numberUses, numberLeft, nextRole);


### PR DESCRIPTION
- Highest rank threshold message should display properly with highest **referral-related role** instead of highest server role or "must create invite link"
- Fixed updating error, last role should be auto-updated
- Also adds together all user's invite use #s, instead of just reading invite with highest # of uses